### PR TITLE
Add example for creating an umami page_view

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ event_resp = umami.new_event(
     custom_data={'client': 'umami-tester-v1'},
     referrer='https://some_url')
 
+# Create a new page view in the pages section of the dashboards.
+page_view_resp = umami.new_page_view(
+    website_id='a7cd-5d1a-2b33', # Only send if overriding default above
+    page_title='Umami-Test', # Defaults to event_name if omitted.
+    hostname='somedomain.com', # Only send if overriding default above.
+    url='/users/actions',
+    referrer='https://some_url')
+
 # Call after logging in to make sure the auth token is still valid.
 umami.verify_token()
 ```


### PR DESCRIPTION
I think mentioning the page view in the README might be helpful. After creating a new site, I initially was confused why the send_event was sending events but I couldn't see any page views on Umami.  Other new users may also assume page_views and events are related, but this way it is clear there are is a way to send page views as well as sending events.